### PR TITLE
project: Flesh out .gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,50 +1,153 @@
-
 Blacklist Blocking/payload/hosts.txt
-
 Blacklist Blocking/payload/nytprof.out
-
 Blacklist Blocking/payload/update-blacklists-dnsmasq.ptkdb
 
 *.tgz
-
 *.worksheet
-
 *.txt
-
 *.bbprojectdata
-
 *.bbprojectsettings
 
 Blacklist Blocking/ersetup
-
 *.boot
-
 *.boot
 
 AdBlock/install_adblock.v3.22rc2
-
 AdBlock/install_adblock.v3.22rc1
-
 AdBlock/install_adblock.v3.15.1
 
 blacklist/browse.VC.db
-
-blacklist/install_dnsmasq_blklist.v3.6beta1
-
-blacklist/install_dnsmasq_blklist.v3.6beta1
-
-blacklist/install_dnsmasq_blklist.v3.6beta1
-
-blacklist/install_adblock.v3.5
-
-blacklist/install_adblock.v3.5
-
-blacklist/install_adblock.v3.5
-
-blacklist/install_dnsmasq_blklist.v3.5
-
-blacklist/install_dnsmasq_blklist.v3.5.5
-
-blacklist/install_dnsmasq_blklist.v3.6-beta.2
+blacklist/install_dnsmasq_blklist.v*
+blacklist/install_adblock.v*
+blacklist/install_dnsmasq_blklist.v*
 
 .DS_Store
+
+# Proper VCS ignores for Perl
+!Build/
+.last_cover_stats
+/META.yml
+/META.json
+/MYMETA.*
+*.o
+*.bs
+
+# Devel::Cover
+cover_db/
+
+# Devel::NYTProf
+nytprof.out
+
+# Dizt::Zilla
+/.build/
+
+# Module::Build
+_build/
+Build
+Build.bat
+
+# Module::Install
+inc/
+
+# ExtUitls::MakeMaker
+/blib/
+/_eumm/
+/*.gz
+/Makefile
+/Makefile.old
+/MANIFEST.bak
+/pm_to_blib
+/*.zip
+
+# Proper VCS ignores for Python
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+env/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*,cover
+.hypothesis/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# pyenv
+.python-version
+
+# celery beat schedule file
+celerybeat-schedule
+
+# dotenv
+.env
+
+# virtualenv
+.venv/
+venv/
+ENV/
+
+# Spyder project settings
+.spyderproject
+
+# Rope project settings
+.ropeproject


### PR DESCRIPTION
While reviewing the project I found that:

  - Files not needed/desired were commited to revision control (`.pyc`
files for example)
  - Rules for both Python and Perl were missing from the `.gitignore`
file.

This update both provides common boilerplate for projects and
consolidated some very version specific strings into more generic ones
(Adblock, Blacklist versions, etc).